### PR TITLE
Improve GRADLE build Performance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,10 @@ buildscript {
 }
 
 allprojects {
+    tasks.withType(Test).configureEach {
+        forkEvery = 100
+    }
+
     repositories {
         if (Boolean.parseBoolean(USE_ALIYUN_REPO)) {
             // Replacement of google()


### PR DESCRIPTION

[Process forking options](https://docs.gradle.org/current/userguide/performance.html#forking_options). Gradle will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork a new test VM after a certain number of tests have run by setting `forkEvery`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
